### PR TITLE
Changing env.PWD to process.cwd() to work on Windows systems.

### DIFF
--- a/lib/floret.js
+++ b/lib/floret.js
@@ -1215,7 +1215,7 @@ let FloretClass;
         root = envVars.FLORET_ROOT;
       }
 
-      root = envStr === 'local' ? envVars.PWD : root;
+      root = envStr === 'local' ? process.cwd()  : root;
       config = JSON.parse(fs.readFileSync(`${root}/floret.json`, 'utf8'));
       config.root = root;
 


### PR DESCRIPTION
Fixes #19 , working successfully on my mac and windows machines.